### PR TITLE
Make String "mod_version" untranslatable

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -273,7 +273,7 @@
     <string name="no_filters_title">No filters set</string>
 
     <!-- About phone screen,  setting option name -->
-    <string name="mod_version">EXODUS version</string>
+    <string name="mod_version" translatable="false">EXODUS version</string>
 
     <!-- Settings switch for updating Cyanogen recovery -->
     <string name="update_recovery_title">Update recovery</string>


### PR DESCRIPTION
Make String "mod_version" untranslatable, that the value is "EXODUS-Version"instead of "Cyanogenmod-Version in all languages(Value is "Cyanogenmod-Version" in other languages than English.
