### PR TITLE
Remove unused string: "contributor_cloud_title"

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -299,8 +299,6 @@
     <string name="advanced_settings">Advanced settings</string>
     <string name="advanced_settings_summary">Enable more settings options</string>
 
-    <string name="contributor_cloud_title">Contributors</string>
-
     <!-- About phone screen, service state -->
     <string name="phone_service_state">Voice: <xliff:g id="voice_state">%1$s</xliff:g>, data: <xliff:g id="data_state">%2$s</xliff:g></string>
 


### PR DESCRIPTION
"contributor_cloud_title" removed, this is used for the Contributors Cloud in Cyanogenmod, but not used in Exodus.
